### PR TITLE
商品一覧表示機能の実装完了

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up,keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birth_date])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birth_date])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!,only: [:new]
+  before_action :authenticate_user!, only: [:new]
 
   def index
-    # 処理
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -18,9 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
-private
+  private
 
   def item_params
-    params.require(:item).permit(:item_name, :description, :category_id, :condition_id, :shipping_fee_id, :prefecture_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:item_name, :description, :category_id, :condition_id, :shipping_fee_id, :prefecture_id,
+                                 :shipping_day_id, :price, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,7 +12,7 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,11 +10,12 @@ class Item < ApplicationRecord
 
   belongs_to :user
 
-  validates :image, presence: true 
-  validates :item_name, presence: true 
-  validates :description, presence: true 
-  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
-  
+  validates :image, presence: true
+  validates :item_name, presence: true
+  validates :description, presence: true
+  validates :price, presence: true,
+                    numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+
   validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :condition_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :shipping_fee_id, numericality: { other_than: 1, message: "can't be blank" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,14 @@ class User < ApplicationRecord
 
   validates :nickname, presence: true
 
-  validates :password,format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/, message: 'is invalid. Include both letters and numbers' }
+  validates :password,
+            format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/, message: 'is invalid. Include both letters and numbers' }
   validates :last_name, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
-  validates :first_name, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
-  validates :last_name_kana, presence: true,format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters' }
-  validates :first_name_kana, presence: true,format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters' }
+  validates :first_name, presence: true,
+                         format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
+  validates :last_name_kana, presence: true,
+                             format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters' }
+  validates :first_name_kana, presence: true,
+                              format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters' }
   validates :birth_date, presence: true
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,7 +120,6 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -128,11 +127,13 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
+      
+    <% if @items.present? %>
+     <% @items.each do |item| %>
+     <li class='list'>
+       <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,22 +144,20 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
+       <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+     <% end %>
+     <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,13 +173,12 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+      <% end %>
+     <% end %>
+    </li>
+   </ul>
   </div>
-  <%# /商品一覧 %>
+
 </div>
 <%= link_to new_item_path, class: 'purchase-btn' do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     association :user
 
-    category_id { 2 } 
+    category_id { 2 }
     condition_id { 2 }
     shipping_fee_id { 2 }
     prefecture_id { 2 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -70,31 +70,31 @@ RSpec.describe Item, type: :model do
       it '価格が300円未満だと出品できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
 
       it '価格が9,999,999円を超えると出品できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
 
       it '価格が全角数字だと出品できない' do
         @item.price = '３０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '価格が半角英字だと出品できない' do
         @item.price = 'three hundred'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '価格が半角英数字混合だと出品できない' do
         @item.price = '3000yen'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it 'userが紐づいていない場合登録できない' do


### PR DESCRIPTION
# What
- 商品一覧表示機能を実装しました。
    - 出品された商品がトップページに一覧で表示されるようにしました。
    - 商品データがない場合は、ダミー商品を表示する仕様を追加しました。
    - 商品の画像・商品名・価格・配送料の負担情報を表示するようにしました。
    - 商品が登録された順に、出品日時が新しい順で表示されるようにしました。

# Why
- 商品一覧を表示することで、ユーザーが出品された商品を視覚的に確認できるようにするため。
- 出品された商品の詳細を確認するための基盤を作るため。
- 商品がない場合にダミー情報を表示し、初めて訪れたユーザーが出品した商品がどのように表示されるかを確認できるようにするため。
- ログインしていないユーザーも一覧表示を確認できることで、ユーザーの興味を引き、サイトの利用促進につなげるため。

# 動画
![商品が一覧で表示されている動画](https://gyazo.com/2446995ddc5ac383bd8c87495e8a318b)

![ 商品のデータがない場合は、ダミー商品が表示されている動画](https://gyazo.com/64dba3d082e88aba2330efeb7ace520e)