### PR TITLE
autheticate_user!のshowを削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :show, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index


### PR DESCRIPTION
ログアウト状態では詳細ページにアクセスできず、ログインページに遷移してしまいました。

# What
items_controller.erbファイル
- [ ] 修正前
` before_action :authenticate_user!, only: [:new, :show, :edit, :update, :destroy]`
- [ ] 修正後
- showを削除しました。
` before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]`

# Why
ログアウト状態のユーザーでも、商品の詳細ページに遷移できるようにして、ユーザーへのフリマアプリの魅力を訴求するため
