### PR TITLE
データベースのリセットコードを記述

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,4 +5,5 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate
+# bundle exec rake db:migrate 
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset


### PR DESCRIPTION
データベースのリセットコードを追記した経緯
# What
render.build.shファイルに`DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset`を記述し、データベースをリセット

# Why
本番環境（render）でusersテーブルに重複が見られる「PG::DuplicateTable: ERROR: relation "users" already exists」エラー表示されたため。

---
```

1. 本番環境（renderデプロイ）で、メンターの最終確認を行ったところ、修正依頼が届いた。
2. 修正依頼内容は「ログインしていないユーザーでも商品詳細表示ページに遷移できるように」＊私の実装の現状は「ログインしていないユーザーがログインページに遷移してしまう」
3.  New Branch「商品詳細ページの修正」を作成し、items_controller.rbファイルのshowを削除`before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]`に修正。
4. ローカルで動作確認し、問題なし。
5. プルリクエスト、自身でコメント、自身でLGTMをだし、マージし、メインブランチに切り替え、pull originで、現在ブランチはメインの状態。
6. しかし、本番環境（render）でusersテーブルに重複が見られる「PG::DuplicateTable: ERROR: relation "users" already exists」エラー表示
```

